### PR TITLE
Use OrviboSettings.js values instead of hardcoded ones in the Example.js

### DIFF
--- a/Example.js
+++ b/Example.js
@@ -4,19 +4,6 @@ const url = require('url');
 
 const httpPort = 3000;
 
-// Create a settings object to pass PK key and map sockets to names
-const settings = {
-    LOG_PACKET: false, //Show incoming packet data from the socket
-    ORVIBO_KEY: '', // put your PK key here as plain text (See Readme)
-    plugInfo : [
-        // Add uid and a name so you can easily identify the connected sockets
-        {
-            uid :'53dd7fe74de7',
-            name: "Lamp in Kitchen"
-        },
-    ],
-};
-
 let orvbio = new Orvibo(settings);
 
 // When a socket first connects and initiates the handshake it will emit the connected event with the uid of the socket;


### PR DESCRIPTION
When I tried to set up the devices I've discovered there's a duplicate of the same data configuration structure and got confused which now should I use. The intention of this PR is to remove the duplication and use the one who's only purpose is exactly that.